### PR TITLE
Update support for Cadence SystemC

### DIFF
--- a/axi/axi_tlm.h
+++ b/axi/axi_tlm.h
@@ -996,7 +996,7 @@ struct axi_initiator_socket
      */
     const char* kind() const override { return "axi_initiator_socket"; }
     // not the right version but we assume TLM is always bundled with SystemC
-#if SYSTEMC_VERSION >= 20181013 // ((TLM_VERSION_MAJOR > 2) || (TLM_VERSION==2 && TLM_VERSION_MINOR>0) ||(TLM_VERSION==2
+#if SYSTEMC_VERSION >= 20181013 || defined(NCSC) // ((TLM_VERSION_MAJOR > 2) || (TLM_VERSION==2 && TLM_VERSION_MINOR>0) ||(TLM_VERSION==2
                                 // && TLM_VERSION_MINOR>0 && TLM_VERSION_PATCH>4))
     type_index get_protocol_types() const override { return typeid(TYPES); }
 #endif
@@ -1028,7 +1028,7 @@ struct axi_target_socket
      */
     const char* kind() const override { return "axi_target_socket"; }
     // not the right version but we assume TLM is always bundled with SystemC
-#if SYSTEMC_VERSION >= 20181013 // ((TLM_VERSION_MAJOR > 2) || (TLM_VERSION==2 && TLM_VERSION_MINOR>0) ||(TLM_VERSION==2
+#if SYSTEMC_VERSION >= 20181013 || defined(NCSC) // ((TLM_VERSION_MAJOR > 2) || (TLM_VERSION==2 && TLM_VERSION_MINOR>0) ||(TLM_VERSION==2
                                 // && TLM_VERSION_MINOR>0 && TLM_VERSION_PATCH>4))
     type_index get_protocol_types() const override { return typeid(TYPES); }
 #endif
@@ -1059,7 +1059,7 @@ struct ace_initiator_socket
      * @return the kind string
      */
     const char* kind() const override { return "axi_initiator_socket"; }
-#if SYSTEMC_VERSION >= 20181013 // not the right version but we assume TLM is always bundled with SystemC
+#if SYSTEMC_VERSION >= 20181013 || defined(NCSC) // not the right version but we assume TLM is always bundled with SystemC
     /**
      * @brief get the type of protocol
      * @return the kind typeid
@@ -1094,7 +1094,7 @@ struct ace_target_socket
      */
     const char* kind() const override { return "axi_target_socket"; }
     // not the right version but we assume TLM is always bundled with SystemC
-#if SYSTEMC_VERSION >= 20181013 // not the right version but we assume TLM is always bundled with SystemC
+#if SYSTEMC_VERSION >= 20181013 || defined(NCSC) // not the right version but we assume TLM is always bundled with SystemC
     /**
      * @brief get the type of protocol
      * @return the kind typeid

--- a/axi/scv/ace_recorder.h
+++ b/axi/scv/ace_recorder.h
@@ -351,7 +351,8 @@ template <typename TYPES> void ace_recorder<TYPES>::b_transport(typename TYPES::
         (*req) = trans;
         req->parent = h;
         req->id = h.get_id();
-        b_timed_peq.notify(*req, tlm::BEGIN_REQ, delay);
+        tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+        b_timed_peq.notify(*req, begin_req, delay);
     }
 
     auto addr = trans.get_address();
@@ -393,7 +394,8 @@ template <typename TYPES> void ace_recorder<TYPES>::b_transport(typename TYPES::
     b_trHandle[trans.get_command()]->end_transaction(h, delay.value(), sc_core::sc_time_stamp());
     // and now the stuff for the timed tx
     if(b_streamHandleTimed) {
-        b_timed_peq.notify(*req, tlm::END_RESP, delay);
+        tlm::tlm_phase end_resp = tlm::END_RESP;
+        b_timed_peq.notify(*req, end_resp, delay);
     }
 }
 
@@ -414,7 +416,8 @@ template <typename TYPES> void ace_recorder<TYPES>::b_snoop(typename TYPES::tlm_
         (*req) = trans;
         req->parent = h;
         req->id = h.get_id();
-        b_timed_peq.notify(*req, tlm::BEGIN_REQ, delay);
+        tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+        b_timed_peq.notify(*req, begin_req, delay);
     }
 
     for(auto& ext : tlm::scc::scv::tlm_extension_recording_registry<TYPES>::inst().get())
@@ -454,7 +457,8 @@ template <typename TYPES> void ace_recorder<TYPES>::b_snoop(typename TYPES::tlm_
     b_trHandle[trans.get_command()]->end_transaction(h, delay.value(), sc_core::sc_time_stamp());
     // and now the stuff for the timed tx
     if(b_streamHandleTimed) {
-        b_timed_peq.notify(*req, tlm::END_RESP, delay);
+        tlm::tlm_phase end_resp = tlm::END_RESP;
+        b_timed_peq.notify(*req, end_resp, delay);
     }
 }
 
@@ -566,7 +570,10 @@ tlm::tlm_sync_enum ace_recorder<TYPES>::nb_transport_fw(typename TYPES::tlm_payl
             req->acquire();
             (*req) = trans;
             req->parent = h;
-            nb_timed_peq.notify(*req, (status == tlm::TLM_COMPLETED && phase == tlm::BEGIN_REQ) ? tlm::END_RESP : phase, delay);
+            tlm::tlm_phase tlm_completed = tlm::TLM_COMPLETED;
+            tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+            tlm::tlm_phase end_resp = tlm::END_RESP;
+            nb_timed_peq.notify(*req, (status == tlm_completed && phase == begin_req) ? end_resp : phase, delay);
         }
     } else if(nb_streamHandleTimed && status == tlm::TLM_UPDATED) {
         tlm_recording_payload* req = mm::get().allocate();
@@ -664,7 +671,10 @@ tlm::tlm_sync_enum ace_recorder<TYPES>::nb_transport_bw(typename TYPES::tlm_payl
             req->acquire();
             (*req) = trans;
             req->parent = h;
-            nb_timed_peq.notify(*req, (status == tlm::TLM_COMPLETED && phase == tlm::BEGIN_REQ) ? tlm::END_RESP : phase, delay);
+            tlm::tlm_phase tlm_completed = tlm::TLM_COMPLETED;
+            tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+            tlm::tlm_phase end_resp = tlm::END_RESP;
+            nb_timed_peq.notify(*req, (status == tlm_completed && phase == begin_req) ? end_resp : phase, delay);
         }
     } else if(nb_streamHandleTimed && status == tlm::TLM_UPDATED) {
         tlm_recording_payload* req = mm::get().allocate();

--- a/axi/scv/axi_recorder.h
+++ b/axi/scv/axi_recorder.h
@@ -322,7 +322,8 @@ void axi_recorder<TYPES>::b_transport(typename TYPES::tlm_payload_type& trans, s
         (*req) = trans;
         req->parent = h;
         req->id = h.get_id();
-        b_timed_peq.notify(*req, tlm::BEGIN_REQ, delay);
+        tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+        b_timed_peq.notify(*req, begin_req, delay);
     }
 
     for(auto& ext : tlm::scc::scv::tlm_extension_recording_registry<TYPES>::inst().get())
@@ -359,7 +360,8 @@ void axi_recorder<TYPES>::b_transport(typename TYPES::tlm_payload_type& trans, s
     b_trHandle[trans.get_command()]->end_transaction(h, delay.value(), sc_core::sc_time_stamp());
     // and now the stuff for the timed tx
     if(b_streamHandleTimed) {
-        b_timed_peq.notify(*req, tlm::END_RESP, delay);
+        tlm::tlm_phase end_resp = tlm::END_RESP;
+        b_timed_peq.notify(*req, end_resp, delay);
     }
 }
 
@@ -468,7 +470,10 @@ tlm::tlm_sync_enum axi_recorder<TYPES>::nb_transport_fw(typename TYPES::tlm_payl
             req->acquire();
             (*req) = trans;
             req->parent = h;
-            nb_timed_peq.notify(*req, (status == tlm::TLM_COMPLETED && phase == tlm::BEGIN_REQ) ? tlm::END_RESP : phase,
+            tlm::tlm_phase tlm_completed = tlm::TLM_COMPLETED;
+            tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+            tlm::tlm_phase end_resp = tlm::END_RESP;
+            nb_timed_peq.notify(*req, (status == tlm_completed && phase == begin_req) ? end_resp : phase,
                                 delay);
         }
     } else if(nb_streamHandleTimed && status == tlm::TLM_UPDATED) {
@@ -562,7 +567,10 @@ tlm::tlm_sync_enum axi_recorder<TYPES>::nb_transport_bw(typename TYPES::tlm_payl
             req->acquire();
             (*req) = trans;
             req->parent = h;
-            nb_timed_peq.notify(*req, (status == tlm::TLM_COMPLETED && phase == tlm::BEGIN_REQ) ? tlm::END_RESP : phase,
+            tlm::tlm_phase tlm_completed = tlm::TLM_COMPLETED;
+            tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+            tlm::tlm_phase end_resp = tlm::END_RESP;
+            nb_timed_peq.notify(*req, (status == tlm_completed && phase == begin_req) ? end_resp : phase,
                                 delay);
         }
     } else if(nb_streamHandleTimed && status == tlm::TLM_UPDATED) {

--- a/chi/chi_tlm.h
+++ b/chi/chi_tlm.h
@@ -968,7 +968,7 @@ struct chi_initiator_socket
      * @return the kind string
      */
     const char* kind() const override { return "chi_trx_initiator_socket"; }
-#if SYSTEMC_VERSION >= 20181013 // not the right version but we assume TLM is always bundled with SystemC
+#if SYSTEMC_VERSION >= 20181013 || defined(NCSC) // not the right version but we assume TLM is always bundled with SystemC
     /**
      * @brief get the type of protocol
      * @return the kind typeid
@@ -1004,7 +1004,7 @@ struct chi_target_socket
      * @return the kind string
      */
     const char* kind() const override { return "chi_trx_target_socket"; }
-#if SYSTEMC_VERSION >= 20181013
+#if SYSTEMC_VERSION >= 20181013 || defined(NCSC)
     /**
      * @brief get the type of protocol
      * @return the kind typeid

--- a/chi/scv/chi_recorder.h
+++ b/chi/scv/chi_recorder.h
@@ -369,7 +369,8 @@ void chi_trx_recorder<TYPES>::b_transport(typename TYPES::tlm_payload_type& tran
         (*req) = trans;
         req->parent = h;
         req->id = h.get_id();
-        b_timed_peq.notify(*req, tlm::BEGIN_REQ, delay);
+        tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+        b_timed_peq.notify(*req, begin_req, delay);
     }
 
     for(auto& ext : tlm::scc::scv::tlm_extension_recording_registry<TYPES>::inst().get())
@@ -402,7 +403,8 @@ void chi_trx_recorder<TYPES>::b_transport(typename TYPES::tlm_payload_type& tran
     b_trHandle[trans.get_command()]->end_transaction(h, delay.value(), sc_core::sc_time_stamp());
     // and now the stuff for the timed tx
     if(b_streamHandleTimed) {
-        b_timed_peq.notify(*req, tlm::END_RESP, delay);
+        tlm::tlm_phase end_resp = tlm::END_RESP;
+        b_timed_peq.notify(*req, end_resp, delay);
     }
 }
 
@@ -424,7 +426,8 @@ void chi_trx_recorder<TYPES>::b_snoop(typename TYPES::tlm_payload_type& trans, s
         (*req) = trans;
         req->parent = h;
         req->id = h.get_id();
-        b_timed_peq.notify(*req, tlm::BEGIN_REQ, delay);
+        tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+        b_timed_peq.notify(*req, begin_req, delay);
     }
 
     for(auto& ext : tlm::scc::scv::tlm_extension_recording_registry<TYPES>::inst().get())
@@ -458,7 +461,8 @@ void chi_trx_recorder<TYPES>::b_snoop(typename TYPES::tlm_payload_type& trans, s
     b_trHandle[trans.get_command()]->end_transaction(h, delay.value());
     // and now the stuff for the timed tx
     if(b_streamHandleTimed) {
-        b_timed_peq.notify(*req, tlm::END_RESP, delay);
+        tlm::tlm_phase end_resp = tlm::END_RESP;
+        b_timed_peq.notify(*req, end_resp, delay);
     }
 }
 
@@ -560,7 +564,10 @@ tlm::tlm_sync_enum chi_trx_recorder<TYPES>::nb_transport_fw(typename TYPES::tlm_
             req->acquire();
             (*req) = trans;
             req->parent = h;
-            nb_timed_peq.notify(*req, (status == tlm::TLM_COMPLETED && phase == tlm::BEGIN_REQ) ? tlm::END_RESP : phase,
+            tlm::tlm_phase tlm_completed = tlm::TLM_COMPLETED;
+            tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+            tlm::tlm_phase end_resp = tlm::END_RESP;
+            nb_timed_peq.notify(*req, (status == tlm_completed && phase == begin_req) ? end_resp : phase,
                                 delay);
         }
     } else if(nb_streamHandleTimed && status == tlm::TLM_UPDATED) {
@@ -648,7 +655,10 @@ tlm::tlm_sync_enum chi_trx_recorder<TYPES>::nb_transport_bw(typename TYPES::tlm_
             req->acquire();
             (*req) = trans;
             req->parent = h;
-            nb_timed_peq.notify(*req, (status == tlm::TLM_COMPLETED && phase == tlm::BEGIN_REQ) ? tlm::END_RESP : phase,
+            tlm::tlm_phase tlm_completed = tlm::TLM_COMPLETED;
+            tlm::tlm_phase begin_req = tlm::BEGIN_REQ;
+            tlm::tlm_phase end_resp = tlm::END_RESP;
+            nb_timed_peq.notify(*req, (status == tlm_completed && phase == begin_req) ? end_resp : phase,
                                 delay);
         }
     } else if(nb_streamHandleTimed && status == tlm::TLM_UPDATED) {


### PR DESCRIPTION
This PR updates the support for Cadence's SystemC versions for XCelium >= 22.